### PR TITLE
move mvn install to the install: step to override the defaut config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
-script:
+install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Djavax.xml.accessExternalSchema=all -B -V
+script:
   - mvn test -B
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This PR moves the mvn install step to the `install:` section of your _.travis.yml_
